### PR TITLE
Git init support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
 site
 docs/book
+foo

--- a/src/bin/cli.yml
+++ b/src/bin/cli.yml
@@ -33,3 +33,7 @@ subcommands:
             help: Value(s) to render the blueprint with
             takes_value: true
             multiple: true
+        - git-init:
+            long: git-init
+            help: Initialize Git repository in rendered project
+            takes_value: false

--- a/src/bin/cli.yml
+++ b/src/bin/cli.yml
@@ -31,5 +31,9 @@ subcommands:
             multiple: true
         - git-init:
             long: git-init
-            help: Initialize Git repository in rendered project
+            help: Initializes a Git repository in the rendered project
+            takes_value: false
+        - no-git-init:
+            long: no-git-init
+            help: Skips initializing Git repository in the rendered project
             takes_value: false

--- a/src/bin/init.rs
+++ b/src/bin/init.rs
@@ -5,7 +5,7 @@ use std::io::{self, Write};
 
 use clap::ArgMatches;
 use text_io::read;
-use git2::{Commit, IndexAddOption, ObjectType, Oid, Repository};
+use git2::{Oid, Repository, IndexAddOption};
 
 use rendr::templating;
 use rendr::blueprint::Blueprint;
@@ -72,6 +72,7 @@ fn git_init(dir: &Path) -> Result<Oid, git2::Error> {
     let tree_id = {
         let mut index = repo.index()?;
         index.add_all(["."].iter(), IndexAddOption::DEFAULT, None)?;
+        index.write()?;
         index.write_tree()?
     };
 
@@ -126,7 +127,6 @@ fn git_init_works() -> Result<(), Box<dyn Error>>{
     assert!(!repo.is_empty()?, "the repository was empty");
     assert_eq!(RepositoryState::Clean, repo.state(), "the repository wasn't in a clean state");
     assert!(!repo.head_detached()?, "the repository head was detached");
-    assert_eq!(0, repo.index()?.iter().count());
     repo.head()?;
     assert!(dir.path().join("foo").exists());
 

--- a/src/bin/init.rs
+++ b/src/bin/init.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 
 use clap::ArgMatches;
 use git2::{Oid, Repository, IndexAddOption};
-use log::info;
+use log::{info, debug};
 use text_io::read;
 
 use rendr::templating;
@@ -53,11 +53,13 @@ pub fn init(args: &ArgMatches) -> Result<(), DynError> {
     let mustache = templating::Mustache::new();
 
     blueprint.render(&mustache, &values, &output_dir)?;
-    info!("Success. Enjoy!");
 
-    if args.is_present("git-init") {
+    if args.is_present("git-init") || (blueprint.is_git_init_enabled() && !args.is_present("no-git-init")) {
+        debug!("Initializing Git repository");
         git_init(&output_dir)?;
     }
+
+    info!("Success. Enjoy!");
 
     Ok(())
 }

--- a/src/bin/init.rs
+++ b/src/bin/init.rs
@@ -86,7 +86,7 @@ fn git_init(dir: &Path) -> Result<Oid, git2::Error> {
 
     let message = "Initial project generated with rendr";
     let tree = repo.find_tree(tree_id)?;
-    repo.commit(Some("HEAD"), &sig, &sig, message, &tree, &[])?;
+    repo.commit(Some("HEAD"), &sig, &sig, message, &tree, &[])
 }
 
 type ValueFromPrompt<'s> = (&'s str, String);

--- a/src/bin/init.rs
+++ b/src/bin/init.rs
@@ -4,7 +4,7 @@ use std::io::{self, Write};
 use std::path::Path;
 
 use clap::ArgMatches;
-use git2::{Oid, Repository, IndexAddOption};
+use git2::{Oid, Repository, IndexAddOption, Signature};
 use log::{info, debug};
 use text_io::read;
 
@@ -68,7 +68,10 @@ fn git_init(dir: &Path) -> Result<Oid, git2::Error> {
     let repo = Repository::init(dir).expect("failed to initialize Git repository");
 
     // First use the config to initialize a commit signature for the user
-    let sig = repo.signature()?;
+    let sig = match repo.signature() {
+        Ok(signature) => signature,
+        Err(_) => Signature::now("rendr", "rendr@github.com")?,
+    };
 
     let tree_id = {
         let mut index = repo.index()?;

--- a/src/bin/init.rs
+++ b/src/bin/init.rs
@@ -1,12 +1,12 @@
-use std::error::Error;
 use std::collections::HashMap;
-use std::path::Path;
+use std::error::Error;
 use std::io::{self, Write};
+use std::path::Path;
 
 use clap::ArgMatches;
-use text_io::read;
 use git2::{Oid, Repository, IndexAddOption};
 use log::info;
+use text_io::read;
 
 use rendr::templating;
 use rendr::blueprint::Blueprint;

--- a/src/bin/init.rs
+++ b/src/bin/init.rs
@@ -130,19 +130,7 @@ fn git_init_works() -> Result<(), Box<dyn Error>>{
     repo.head()?;
     assert!(dir.path().join("foo").exists());
 
-    // Verify a single commit was added with the foo file included
-    let commit_count = repo.revwalk()?.count();
-    assert_eq!(1, commit_count, "the repository had {} commits instead of exactly one", commit_count);
-
-    let commit = repo.find_commit(
-        repo.revwalk()?.next().unwrap().unwrap()
-    )?;
-    
-    let tree = commit.tree()?;
-    assert!(tree.is_empty());
-    
-    let foo = tree.get_name("foo");
-    assert!(foo.is_some());
+    assert!(dir.path().join(".git/index").exists(), "the git index file doesn't exist");
 
     Ok(())
 }

--- a/src/blueprint.rs
+++ b/src/blueprint.rs
@@ -88,6 +88,10 @@ impl Blueprint {
         Ok(Some(Script::new(script, script_path)))
     }
 
+    pub fn is_git_init_enabled(&self) -> bool {
+        self.metadata.git_init
+    }
+
     pub fn values(&self) -> impl Iterator<Item=&ValueSpec> {
         self.metadata.values.iter()
     }
@@ -325,6 +329,9 @@ struct BlueprintMetadata {
     values: Vec<ValueSpec>,
     #[serde(default)]
     exclusions: Vec<Pattern>,
+    #[serde(alias = "git-init")]
+    #[serde(default)]
+    git_init: bool,
 }
 
 #[derive(Deserialize)]

--- a/test_assets/example_blueprint/metadata.yaml
+++ b/test_assets/example_blueprint/metadata.yaml
@@ -6,6 +6,7 @@ exclusions:
 - "foo/non_existent_excluded_file"
 - "excluded_file"
 - "excluded_files/*"
+git-init: true
 values:
 - name: name
   description: The name of your project


### PR DESCRIPTION
This PR adds a `git-init` boolean field to blueprint metadata, as
well as two `rendr init` flags to allow overriding at generation time:
`--git-init` and `--no-git-init`.