### PR TITLE
Hc 2301 rendr watch cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -496,6 +496,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed85775dcc68644b5c950ac06a2b23768d3bc9390464151aaf27136998dcf9e"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "flate2"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -527,6 +539,25 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "fsevent"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ab7d1bd1bd33cc98b0889831b72da23c0aa4df9cec7e0702f46ecea04b35db6"
+dependencies = [
+ "bitflags",
+ "fsevent-sys",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f41b048a94555da0f42f1d632e2e19510084fb8e303b0daa2816e733fb3644a0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "fuchsia-cprng"
@@ -753,6 +784,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4816c66d2c8ae673df83366c18341538f234a26d65a9ecea5c348b453ac1d02f"
+dependencies = [
+ "bitflags",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e74a1aa87c59aeff6ef2cc2fa62d41bc43f54952f55652656b18a02fd5e356c0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "iovec"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -791,6 +842,12 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
@@ -950,6 +1007,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio-extras"
+version = "2.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19"
+dependencies = [
+ "lazycell",
+ "log 0.4.8",
+ "mio",
+ "slab",
+]
+
+[[package]]
 name = "mio-uds"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1008,6 +1077,24 @@ checksum = "2ba7c918ac76704fb42afcbbb43891e72731f3dcca3bef2a19786297baf14af7"
 dependencies = [
  "cfg-if",
  "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "notify"
+version = "4.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80ae4a7688d1fab81c5bf19c64fc8db920be8d519ce6336ed4e7efe024724dbd"
+dependencies = [
+ "bitflags",
+ "filetime",
+ "fsevent",
+ "fsevent-sys",
+ "inotify",
+ "libc",
+ "mio",
+ "mio-extras",
+ "walkdir",
  "winapi 0.3.9",
 ]
 
@@ -1447,6 +1534,7 @@ dependencies = [
  "glob",
  "log 0.4.8",
  "mustache",
+ "notify",
  "openssl",
  "pathdiff",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ glob = "0.3.0"
 log = { version = "0.4", features = ["std", "serde"] }
 env_logger = "0.7.1"
 pathdiff = "0.2.0"
+notify = "4.0.15"
 
 [dev-dependencies]
 cargo-release = "0.13.0"

--- a/src/bin/cli.yml
+++ b/src/bin/cli.yml
@@ -5,35 +5,40 @@ settings:
   - StrictUtf8
 args:
 subcommands:
-  - init:
-      about: Initializes a project from a blueprint
-      args:
-        - blueprint:
-            short: b
-            long: blueprint
-            required: true
-            help: The location of the blueprint (a git repo or a local directory)
-            takes_value: true
-        - name:
-            required: true
-            help: The name of the project
-            takes_value: true
-        - dir:
-            short: d
-            long: dir
-            help: The output directory name
-            takes_value: true
-        - value:
-            short: v
-            long: value
-            help: Value(s) to render the blueprint with
-            takes_value: true
-            multiple: true
-        - git-init:
-            long: git-init
-            help: Initializes a Git repository in the rendered project
-            takes_value: false
-        - no-git-init:
-            long: no-git-init
-            help: Skips initializing Git repository in the rendered project
-            takes_value: false
+- init:
+    about: Initializes a project from a blueprint
+    args:
+    - blueprint:
+        short: b
+        long: blueprint
+        required: true
+        help: The location of the blueprint (a git repo or a local directory)
+        takes_value: true
+    - name:
+        required: true
+        help: The name of the project
+        takes_value: true
+    - dir:
+        short: d
+        long: dir
+        help: The output directory name
+        takes_value: true
+    - value:
+        short: v
+        long: value
+        help: Value(s) to render the blueprint with
+        takes_value: true
+        multiple: true
+    - git-init:
+        long: git-init
+        help: Initializes a Git repository in the rendered project
+        takes_value: false
+    - no-git-init:
+        long: no-git-init
+        help: Skips initializing Git repository in the rendered project
+        takes_value: false
+    - watch:
+        long: watch
+        short: w
+        takes_value: false
+        help: After initializing the scaffold, watch the filesystem for changes to the blueprint and reinitalize the scaffold when they are detected.

--- a/src/bin/cli.yml
+++ b/src/bin/cli.yml
@@ -5,40 +5,40 @@ settings:
   - StrictUtf8
 args:
 subcommands:
-- init:
-    about: Initializes a project from a blueprint
-    args:
-    - blueprint:
-        short: b
-        long: blueprint
-        required: true
-        help: The location of the blueprint (a git repo or a local directory)
-        takes_value: true
-    - name:
-        required: true
-        help: The name of the project
-        takes_value: true
-    - dir:
-        short: d
-        long: dir
-        help: The output directory name
-        takes_value: true
-    - value:
-        short: v
-        long: value
-        help: Value(s) to render the blueprint with
-        takes_value: true
-        multiple: true
-    - git-init:
-        long: git-init
-        help: Initializes a Git repository in the rendered project
-        takes_value: false
-    - no-git-init:
-        long: no-git-init
-        help: Skips initializing Git repository in the rendered project
-        takes_value: false
-    - watch:
-        long: watch
-        short: w
-        takes_value: false
-        help: After initializing the scaffold, watch the filesystem for changes to the blueprint and reinitalize the scaffold when they are detected.
+  - init:
+      about: Initializes a project from a blueprint
+      args:
+        - blueprint:
+            short: b
+            long: blueprint
+            required: true
+            help: The location of the blueprint (a git repo or a local directory)
+            takes_value: true
+        - name:
+            required: true
+            help: The name of the project
+            takes_value: true
+        - dir:
+            short: d
+            long: dir
+            help: The output directory name
+            takes_value: true
+        - value:
+            short: v
+            long: value
+            help: Value(s) to render the blueprint with
+            takes_value: true
+            multiple: true
+        - git-init:
+            long: git-init
+            help: Initializes a Git repository in the rendered project
+            takes_value: false
+        - no-git-init:
+            long: no-git-init
+            help: Skips initializing Git repository in the rendered project
+            takes_value: false
+        - watch:
+            long: watch
+            short: w
+            takes_value: false
+            help: After initializing the scaffold, watch the filesystem for changes to the blueprint and reinitalize the scaffold when they are detected.

--- a/src/bin/init.rs
+++ b/src/bin/init.rs
@@ -12,8 +12,7 @@ use text_io::read;
 use notify::{Watcher, RecursiveMode, watcher};
 
 use rendr::templating;
-use rendr::blueprint::Blueprint;
-use rendr::blueprint::ValueSpec;
+use rendr::blueprint::{Blueprint, ValueSpec};
 
 type DynError = Box<dyn Error>;
 
@@ -47,7 +46,7 @@ pub fn init(args: &ArgMatches) -> Result<(), DynError> {
         .collect();
     values.extend(prompt_values);
 
-    init_scaffold(args, values.clone())?;
+    init_scaffold(args, &values)?;
 
     if args.is_present("watch") {
         info!("Watching for blueprint changes...");
@@ -69,7 +68,7 @@ pub fn init(args: &ArgMatches) -> Result<(), DynError> {
                     debug!("Watch event: {:?}", event);
                     info!("Blueprint changed! Recreating scaffold...");
                     std::fs::remove_dir_all(scaffold_path)?;
-                    init_scaffold(args, values.clone())?;
+                    init_scaffold(args, &values)?;
                     info!("Success!");
                 },
                 Err(e) => error!("watch error: {:?}", e),
@@ -80,7 +79,7 @@ pub fn init(args: &ArgMatches) -> Result<(), DynError> {
     Ok(())
 }
 
-pub fn init_scaffold(args: &ArgMatches, values: HashMap<&str, &str>) -> Result<(), DynError> {
+fn init_scaffold(args: &ArgMatches, values: &HashMap<&str, &str>) -> Result<(), DynError> {
     // Parse CLI arguments.
     let blueprint_path = args.value_of("blueprint").unwrap();
     let name = args.value_of("name").unwrap();

--- a/src/bin/init.rs
+++ b/src/bin/init.rs
@@ -80,7 +80,9 @@ fn watch(
                 debug!("Watch event: {:?}", event);
                 info!("Blueprint changed! Recreating scaffold...");
                 std::fs::remove_dir_all(scaffold_path)?;
-                init_scaffold(args, values)?;
+                if let Err(e) = init_scaffold(args, values) {
+                    error!("{}", e);
+                }
             },
             Err(e) => error!("watch error: {:?}", e),
         }

--- a/src/bin/init.rs
+++ b/src/bin/init.rs
@@ -69,7 +69,6 @@ pub fn init(args: &ArgMatches) -> Result<(), DynError> {
                     info!("Blueprint changed! Recreating scaffold...");
                     std::fs::remove_dir_all(scaffold_path)?;
                     init_scaffold(args, &values)?;
-                    info!("Success!");
                 },
                 Err(e) => error!("watch error: {:?}", e),
             }


### PR DESCRIPTION
This adds a new parameter to the `init` subcommand that makes `rendr` watch for blueprint changes in the filesystem and regenerate the scaffold when necessary.