### PR TITLE
Enable multiple upgrade scripts between versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1065,7 +1065,7 @@ dependencies = [
 
 [[package]]
 name = "rendr"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "cargo-release",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rendr"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["Brian Stewart <brian.stewart@jamf.com>", "Tomasz Kurcz <tomasz.kurcz@jamf.com>"]
 description = "A project scaffolding tool"
 categories = ["command-line-utilities", "development-tools"]

--- a/src/project.rs
+++ b/src/project.rs
@@ -214,6 +214,7 @@ impl<'p> Project<'p> {
         values.extend(prompt_values);
 
         // Update the target version, inserting if it does not exist for some reason
+        let source_version = config.version;
         let target_version = blueprint.metadata.version.to_string();
         let v = values.entry("version").or_insert(target_version.as_str());
         *v = target_version.as_str();
@@ -231,6 +232,7 @@ impl<'p> Project<'p> {
                 &values.into(),
                 &self.path,
                 &config.source,
+                &source_version,
                 dry_run,
             )
             .map_err(|e| UpgradeError::RenderError(anyhow!("error rendering upgrade: {}", e)))?;


### PR DESCRIPTION
This change enables running every upgrade script from `current_version+1` to `latest_version`. Example, say a project was previously generated with version `2` of a blueprint, and later is upgraded with `rendr upgrade` to the latest version of the blueprint, which is version `5`. Previously only the upgrade script for version `5` would run. Now all upgrade scripts from versions `3`, `4`, and `5` will run. This makes for a better (and more correct) upgrade experience.

This will be released as Rendr version `1.1.0`.